### PR TITLE
Migrate 3 functions in the *.pm to *.xs

### DIFF
--- a/Brotli.xs
+++ b/Brotli.xs
@@ -200,6 +200,85 @@ _mode(self, mode)
     RETVAL
 
 SV*
+compress(self, in)
+    IO::Compress::Brotli self
+    SV* in
+  CODE:
+    ENTER;
+    SAVETMPS;
+ 
+    PUSHMARK(SP);
+    XPUSHs(ST(0));
+    XPUSHs(in);
+    XPUSHs(newSVuv(BROTLI_OPERATION_PROCESS));
+    PUTBACK;
+
+    call_method("_compress", G_SCALAR);
+
+    SPAGAIN;
+
+    RETVAL = POPs;
+    SvREFCNT_inc(RETVAL);
+
+    PUTBACK;
+    FREETMPS;
+    LEAVE;
+  OUTPUT:
+    RETVAL
+
+SV*
+flush(self)
+    IO::Compress::Brotli self
+  CODE:
+    ENTER;
+    SAVETMPS;
+ 
+    PUSHMARK(SP);
+    XPUSHs(ST(0));
+    XPUSHs(newSVpv("", 0));
+    XPUSHs(newSVuv(BROTLI_OPERATION_FLUSH));
+    PUTBACK;
+
+    call_method("_compress", G_SCALAR);
+
+    SPAGAIN;
+
+    RETVAL = POPs;
+    SvREFCNT_inc(RETVAL);
+
+    PUTBACK;
+    FREETMPS;
+    LEAVE;
+  OUTPUT:
+    RETVAL
+
+SV*
+finish(self)
+    IO::Compress::Brotli self
+  CODE:
+    ENTER;
+    SAVETMPS;
+ 
+    PUSHMARK(SP);
+    XPUSHs(ST(0));
+    XPUSHs(newSVpv("", 0));
+    XPUSHs(newSVuv(BROTLI_OPERATION_FINISH));
+    PUTBACK;
+
+    call_method("_compress", G_SCALAR);
+
+    SPAGAIN;
+
+    RETVAL = POPs;
+    SvREFCNT_inc(RETVAL);
+
+    PUTBACK;
+    FREETMPS;
+    LEAVE;
+  OUTPUT:
+    RETVAL
+
+SV*
 _compress(self, in, op)
     IO::Compress::Brotli self
     SV* in

--- a/lib/IO/Compress/Brotli.pm
+++ b/lib/IO/Compress/Brotli.pm
@@ -23,25 +23,6 @@ sub mode {
     _mode($$self, $mode)
 }
 
-use constant {
-    BROTLI_OPERATION_PROCESS => 0,
-    BROTLI_OPERATION_FLUSH   => 1,
-    BROTLI_OPERATION_FINISH  => 2
-};
-sub compress {
-	my ($self, $data) = @_;
-	$self->_compress($data, BROTLI_OPERATION_PROCESS )
-}
-
-sub flush {
-	my ($self) = @_;
-	$self->_compress('', BROTLI_OPERATION_FLUSH )
-}
-
-sub finish {
-	my ($self) = @_;
-	$self->_compress('', BROTLI_OPERATION_FINISH )
-}
 
 1;
 __END__


### PR DESCRIPTION
This is a bit more verbose, and transition back & forth between perl &
C types in e.g. perl -> compress -> _compress is a bit silly, ideally
"compress" would just call a shared C function.

But this is just an as-is port of what it's doing now which avoids
hardcoding library constants in the *.pm, this could also be done with
ExtUtils::Constant, but whatever.

This leaves the mode() function unported, but it's not used
anywhere (WIP code?) and in any case could also be easily ported over.
